### PR TITLE
Remove scrollbars on windows.

### DIFF
--- a/css/als_lightbox.css
+++ b/css/als_lightbox.css
@@ -8,9 +8,7 @@
 	border-radius: 1em;
 	background: transparent;
 }
-.als_fancybox .fancybox-inner {
-    overflow: hidden !important;
-}
+
 .als_fancybox .fancybox-close {
     top: -12px;
     right: -9px;
@@ -32,7 +30,6 @@
     }
 
     .als_fancybox .fancybox-inner {
-		overflow: scroll !important; /* Allow overlay to scroll on mobile. */
 		border-radius: 10px;
 	}
 


### PR DESCRIPTION
Issue here is that iPhone wants `overflow: scroll;` and Windows wants
`overflow: hidden;` on `.fancybox-inner`. Good news is that Fancybox is
actually figuring this out dynamically and applying the right value
inline on the `.fancybox-inner` element.

Not entirely sure why this was implemented in the first place, so be
sure to keep an eye on live assets. But i tested this on the Clinton
Foundation lightbox and it worked fine.
