### PR TITLE
Bugfix/windows scrollbar

### DIFF
--- a/css/als_lightbox.css
+++ b/css/als_lightbox.css
@@ -53,6 +53,9 @@
 		/* Fullscreen on iPhone 6s. */
 		max-width: 414px;
 
+		/* Full-screen iPhone 6 height in dips. */
+		max-height: 667px;
+
 		margin-left: auto;
 		margin-right: auto;
   }


### PR DESCRIPTION
Fancy box will dynamically set css `overflow` based on whether device
accepts touch input or not. Touch-enabled laptops throw this for a
loop, so now on all large screen, we’ll hide scrollbars.

Also now setting a max-height on small screens. This change is most noticeable on tablets that now get a phone-sized and -shaped lightbox. (Trust me, this looks good.)
